### PR TITLE
fix for broken dc-qualifier on input-forms.staging.xml

### DIFF
--- a/dspace/config/input-forms.staging.xml
+++ b/dspace/config/input-forms.staging.xml
@@ -3467,8 +3467,7 @@ add this to DOCTYPE tag (without single quotes) ' SYSTEM "J:/Working Groups/XML_
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
-					<dc-qualifier>alternative</dc
-					-qualifier>
+					<dc-qualifier>alternative</dc-qualifier>
 					<repeatable>true</repeatable>
 					<label>Schedule title</label>
 					<input-type>onebox</input-type>


### PR DESCRIPTION
A minor edit to fix the broken dc-qualifier (see https://tech.lib.ohio-state.edu/jira/browse/KB-537) in the source tree.
